### PR TITLE
added raw urls support - on parsing and sending sending requests

### DIFF
--- a/cmd/requester.go
+++ b/cmd/requester.go
@@ -15,6 +15,7 @@ import (
 	"unicode"
 
 	"github.com/fatih/color"
+	"github.com/slicingmelon/go-rawurlparser"
 	"github.com/zenthangplus/goccm"
 )
 
@@ -377,7 +378,7 @@ func requestMidPaths(options RequestOptions) {
 	x := strings.Split(options.uri, "/")
 	var uripath string
 
-	parsedURL, err := url.Parse(options.uri)
+	parsedURL := rawurlparser.RawURLParse(options.uri)
 	if err != nil {
 		log.Println(err)
 	}
@@ -481,11 +482,11 @@ func parseCurlOutput(output string, httpVersion string) Result {
 func requestPathCaseSwitching(options RequestOptions) {
 	color.Cyan("\n━━━━━━━━━━━━ PATH CASE SWITCHING ━━━━━━━━━━━━━")
 
-	parsedURL, err := url.Parse(options.uri)
-	if err != nil {
-		log.Println(err)
-		return
-	}
+	parsedURL := rawurlparser.RawURLParse(options.uri)
+	// if err != nil {
+	// 	log.Println(err)
+	// 	return
+	// }
 
 	baseuri := parsedURL.Scheme + "://" + parsedURL.Host
 	uripath := strings.Trim(parsedURL.Path, "/")

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module nomore403
 
-go 1.19
+go 1.23.1
 
 require (
 	github.com/fatih/color v1.13.0
@@ -19,6 +19,7 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.5 // indirect
+	github.com/slicingmelon/go-rawurlparser v0.0.0-20241101212355-a74dbff109f7 // indirect
 	github.com/spf13/afero v1.8.2 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -159,6 +159,8 @@ github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.6.1 h1:/FiVV8dS/e+YqF2JvO3yXRFbBLTIuSDkuC7aBOAvL+k=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/slicingmelon/go-rawurlparser v0.0.0-20241101212355-a74dbff109f7 h1:6xhzr51FYZpfVeGHp8M15WuIF+MbyN5ZcnoQRBEAX2A=
+github.com/slicingmelon/go-rawurlparser v0.0.0-20241101212355-a74dbff109f7/go.mod h1:xUf2JAg8Wkk4L26ByKhkAcqBeHzDdQ+m2QPZAY+g7y4=
 github.com/spf13/afero v1.8.2 h1:xehSyVa0YnHWsJ49JFljMpg1HX19V6NDZ1fkm1Xznbo=
 github.com/spf13/afero v1.8.2/go.mod h1:CtAatgMJh6bJEIs48Ay/FOnkljP3WeGUG0MC1RfAqwo=
 github.com/spf13/cast v1.5.0 h1:rj3WzYc11XZaIZMPKmwP96zkFEnnAmV8s6XbB2aY32w=


### PR DESCRIPTION
Since I liked your tool, I tried it and realized that it is not working correctly. Looking through the code, I saw that you use url.UrlParse to parse the URL then I checked the function that you are using to send requests.

Go is "pro-security" and functions like UrlParse will apply encodings, normalizations, etc, meaning that your payloads from midpaths and endpaths won't work. 
On the other hand, Go's `http.Client` will also apply encodings, normalizations, in the idea to prevent vulnerabilities such as path traversal, etc.

I researched, and there is no URL parser in go that can return raw urls/paths.
For this, I wrote a simple pkg that I published here: https://github.com/slicingmelon/go-rawurlparser.

I forked your tool, made the modifications to use my pkg to parse URLs, and then patched the request() func to be able to send all the payloads as they should be sent, similar to what `curl --path-as-is` does. I  found that the only way to still use `http.Request` and send raw URLs is to set the Opaque to the raw path. 

I've tested it, and it looks like it's working well now; I also intercepted the traffic with Burp, and all the payloads are sent as expected.

If for any reason you want back http.NewRequest instead of http.Request, you can achieve the same thing, too; just don't forget to set the Opaque. 


